### PR TITLE
Add base editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Fixes #19 

## Motivation
This'll sync some code style ideas across editors and OSes. This'll also be documentation for the code style preferences that we want to have in place.

See documentation [here](https://editorconfig.org/).

## Changes
Add editorconfig file

## Testing
Make sure that you're either using an editor that natively supports an `editorconfig` file or that you have the plugin installed for the editor you're using (see docs for where your editor falls).

Open a code file, add some trailing whitespace, save, and see that it's now gone (as an example of a rule working).