### PR TITLE
Add testing + Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.7"
+install:
+  - pip install -r requirements-dev.txt
+# command to run tests
+script:
+  - pytest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://www.travis-ci.org/RoaringForkTech/project-kronos.svg?branch=master)](https://www.travis-ci.org/RoaringForkTech/project-kronos)
+
 # Project Kronos
 
 A Roaring Fork Technologists community project

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+# Matches all files in all subdirectories that end in "tests" or "Test"
 python_files=*tests.py *Test.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files=*tests.py *Test.py

--- a/src/calendar_provider.py
+++ b/src/calendar_provider.py
@@ -2,11 +2,11 @@ from typing import Any, Dict
 
 
 class CalendarProvider:
-    
+
     def get_calendar(self, url: str) -> Dict[str, Any]:
         """
         Fetch the content from url
-        
+
         Args:
             url: url of target calendar
 

--- a/src/event_url_provider.py
+++ b/src/event_url_provider.py
@@ -5,9 +5,9 @@ class EventUrlProvider:
     """
     I am the source of known event calendar urls
     """
-    
+
     def get_urls(self) -> Dict[str, str]:
         """
-        Return a map of evant name -> url
+        Return a map of event name -> url
         """
         return {}

--- a/src/tests/calendar_provider_tests.py
+++ b/src/tests/calendar_provider_tests.py
@@ -1,0 +1,12 @@
+from ..calendar_provider import CalendarProvider
+
+
+def test_get_calendar_returns_a_dictionary():
+    """
+    NOTE: This is a pretty vacuous test, especially
+    since we've got type hinting in place. However,
+    we're putting in place to give pytest something
+    to run until we get more substantive tests in place.
+    """
+    provider = CalendarProvider()
+    assert isinstance(provider.get_calendar('dummy url'), dict)


### PR DESCRIPTION
Fixes #21 

## Motivation
CI/CD is wonderful technology. Travis provides it for free to open-source projects, and has better licensing than most of the other CI providers out there.

This'll allow us to start writing tests against our codebase and see that they pass before we merge them into master.

## TODO
I need approval on adding TravisCI to the RFT organization before I can see that builds are working and add a badge to the README. @stevetarver @justinlewis can one of you guys approve that?

## Discussion
In projects that I've previously worked on, we've kept tests right next to the files that they test. It's a bit more clutter in folders, but I like it because it's easy to navigate to the tests for a given module, and importing the module code into the test is super easy (since it's a sibling import). Thoughts on moving in that direction?

## Changes
* Add `pytest.ini` file that tells it which files are our test files
* Add a dummy test for the calendar provider so that we have something to run
* Do some whitespace + comment tweaking
* Add an `__init__.py` file to the test folder so that relative imports work
* Add a travis.yml file that runs the tests
* Add a badge to the README that shows the current status of tests