### PR TITLE
Get data from a google calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,12 @@ ENV/
 env.bak/
 venv.bak/
 
+# Google oauth credentials from the google provider
+# TODO: remove these when we find a better place/way of
+# storing them
+credentials.json
+authorized.json
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from src.event_enricher import EventEnricher
 from src.event_parser import EventParser
 from src.event_pusher import EventPusher
 from src.event_url_provider import EventUrlProvider
-from src.providers.eventbrite_provider import EventbriteEventProvider
+from src.providers import EventbriteEventProvider, GoogleProvider
 
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 certifi==2019.11.28
 chardet==3.0.4
 eventbrite==3.3.3
+google-api-python-client==1.7.11
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.4.1
 idna==2.8
 requests==2.22.0
 urllib3==1.25.7

--- a/src/calendar_provider.py
+++ b/src/calendar_provider.py
@@ -15,4 +15,3 @@ class CalendarProvider:
             resp = event_brite.find_events(query_params="expand=venue")
 
             return resp
-

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,0 +1,2 @@
+from .google_provider import GoogleProvider # noqa
+from .eventbrite_provider import EventbriteEventProvider # noqa

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,2 +1,2 @@
-from .google_provider import GoogleProvider # noqa
-from .eventbrite_provider import EventbriteEventProvider # noqa
+from providers.google_provider import GoogleProvider # noqa
+from providers.eventbrite_provider import EventbriteEventProvider # noqa

--- a/src/providers/eventbrite_provider.py
+++ b/src/providers/eventbrite_provider.py
@@ -1,5 +1,3 @@
-from pathlib import PurePath
-from pprint import pprint
 from typing import Dict, Any
 
 from src.event_provider import EventProviderABC
@@ -35,7 +33,7 @@ class EventbriteEventProvider(EventProviderABC):
         Returns:
             response body in python native form
 
-        
+
         Example requests:
             * /organizations/350577373737/events?page_size=200&status=live
         """
@@ -64,4 +62,3 @@ class EventbriteEventProvider(EventProviderABC):
 
     def _get_headers(self):
         return {"Authorization": f"Bearer {self.api_key}"}
-

--- a/src/providers/google_provider.py
+++ b/src/providers/google_provider.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+import datetime
+import os.path
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+
+from src.event_provider import EventProviderABC
+
+# If modifying these scopes, delete the file token.pickle.
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+
+
+def get_credentials():
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    # TODO: redo this as json (see from_authorized_user_file - is that the same
+    # as just casting it to json?)
+    if os.path.exists('authorized.json'):
+        creds = Credentials.from_authorized_user_file('authorized.json')
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds:
+        if creds and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json',
+                SCOPES,
+            )
+            creds = flow.run_local_server(port=0)
+        # Save the credentials for the next run
+        with open('authorized.json', 'w') as auth_file:
+            auth_file.write(creds.to_json())
+
+    return creds
+
+
+class GoogleProvider(EventProviderABC):
+    def find_events(self):
+        credentials = get_credentials()
+        service = build('calendar', 'v3', credentials=credentials)
+
+        # Call the Calendar API
+        # 'Z' indicates UTC time
+        now = datetime.datetime.utcnow().isoformat() + 'Z'
+        events_result = service.events().list(
+            calendarId='primary',
+            timeMin=now,
+            maxResults=10,
+            singleEvents=True,
+            orderBy='startTime',
+        ).execute()
+        return events_result.get('items', [])


### PR DESCRIPTION
Fixes #22

## Motivation
We've talked about using google's data model as a starting place for our own data model, so it's gonna help to be able to look at google's data model. This implements oauth authentication against a google account and then pulling the most recent 10 events from the API, which can then be printed or stored as desired.

## Current limitations

* File-based storage of oauth credentials. These should be stored in a database once we've got one available to us.
* Oauth flow is currently done by running a local web browser. That flow is going to need to be reworked once we have a web server as one of our services.

## Open Questions
Are we going to get authorization against each of the organizations we want to partner with, or are we going to pass through the events through another means? It doesn't seem like you can restrict an application to reading only one calendar of yours, which means that other organizations would need to be comfortable with us having access to _all_ of their calendars.

Otherwise @coloradobum was talking about other orgs providing an event stream to our calendar somehow through the Google Calendar interface, which would mean we only have to pull from our own calendar. I haven't researched how this would work.

## Changes
See commit messages
## Testing
Create an application using [the button on the google calendar API docs](https://developers.google.com/calendar/quickstart/python). Save the `credentials.json` file to the repository root.

Go into the body of `main.py`, comment out or delete the body, and replace with:
```python
from pprint import pprint
pprint(GoogleProvider().find_events())
```
Run it and see that you're taken through an oauth process and that the events are then logged to the console.