### PR TITLE
Add linter to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ install:
   - pip install -r requirements-dev.txt
 # command to run tests
 script:
+  - flake8
   - pytest

--- a/main.py
+++ b/main.py
@@ -4,15 +4,10 @@ I am the main entry point to this program
 """
 from typing import Dict, Any
 
-from requests import Response
 from dotenv import load_dotenv
 
 from src.calendar_provider import CalendarProvider
-from src.event_enricher import EventEnricher
-from src.event_parser import EventParser
-from src.event_pusher import EventPusher
 from src.event_url_provider import EventUrlProvider
-from src.providers import EventbriteEventProvider, GoogleProvider
 
 # Pull in environment variables from dotenv file
 load_dotenv()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ black
 ipython
 mypy
 pytest
+flake8

--- a/src/event_enricher.py
+++ b/src/event_enricher.py
@@ -5,9 +5,9 @@ class EventEnricher:
     def enrich(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         I provide additional data for an event
-        
+
         The data is enriched in-place, but also returned for convenience
-        
+
         Args:
             data: calendar data in our datastore format
 

--- a/src/event_parser.py
+++ b/src/event_parser.py
@@ -5,10 +5,10 @@ class EventParser:
     def parse(self, calendar: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         I parse raw event data into a neutral form
-        
+
         If given a google calendar, I transform the raw data into our datastore
         format.
-        
+
         Args:
             calendar:
 

--- a/src/event_provider.py
+++ b/src/event_provider.py
@@ -11,7 +11,7 @@ class EventProviderABC(ABC):
     def find_events(self, query_params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Fetch the content from url
-        
+
         Args:
             query_params: describe type of search
 

--- a/src/event_pusher.py
+++ b/src/event_pusher.py
@@ -5,7 +5,7 @@ class EventPusher:
     def push(self, data: Dict[str, Any]) -> None:
         """
         I push well-formed events to our data store
-        
+
         Args:
             data: a well-formed calendar event (in datastore format)
         """

--- a/src/event_url_provider.py
+++ b/src/event_url_provider.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Dict
 
 
 class EventUrlProvider:

--- a/src/providers/eventbrite_provider.py
+++ b/src/providers/eventbrite_provider.py
@@ -8,9 +8,6 @@ from ..config.eventbrite_config import orgs
 
 
 class EventbriteEventProvider(EventProviderABC):
-    """
-
-    """
 
     def __init__(self, api_key: str):
         """
@@ -58,7 +55,6 @@ class EventbriteEventProvider(EventProviderABC):
                 print("There are more events which we can ignore for now...")
 
         return all_events
-
 
     def _get_headers(self):
         return {"Authorization": f"Bearer {self.api_key}"}

--- a/src/providers/meetup_provider.py
+++ b/src/providers/meetup_provider.py
@@ -4,10 +4,6 @@ from src.event_provider import EventProviderABC
 
 
 class MeetupEventProvider(EventProviderABC):
-    """
-    
-    """
-
     def find_events(self, url: str, headers, query_params) -> Dict[str, Any]:
         """
         Fetch the content from url

--- a/src/tests/calendar_provider_tests.py
+++ b/src/tests/calendar_provider_tests.py
@@ -1,9 +1,8 @@
 from src.calendar_provider import CalendarProvider
 from unittest import TestCase
 
+
 class CalendarProviderTest(TestCase):
-
-
     def test_no_name_find_events_returns_none(self):
         """
         NOTE: This is a pretty vacuous test, especially

--- a/src/tests/eventbrite_provider_tests.py
+++ b/src/tests/eventbrite_provider_tests.py
@@ -1,5 +1,4 @@
 import os
-from pprint import pprint
 from unittest import TestCase
 
 from src.providers.eventbrite_provider import EventbriteEventProvider
@@ -17,5 +16,3 @@ class EventbriteEventProviderTest(TestCase):
 
         # TODO: decouple from the actual EventBrite API to follow best practice
         assert isinstance(provider.find_events(query_params=""), list)
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[flake8]
+# E501: Line too long 80char
+# E261: At least two spaces before inline comment
+# W503: Line break before binary operator (this one is a bad rule.)
+ignore = E501,E261,W503
+


### PR DESCRIPTION
Fixes #28 

## Motivation
This'll do a lot to keep style consistent, and flake8 will also catch a whole lot of stupid mistakes.

## Changes
See commit messages. Note that I removed a bunch of boilerplate code that hasn't been used yet - I'm personally okay with this on YAGNI, but we can also address this using `# noqa` comments.
## Testing
Run `flake8` on your local and see that it comes back clean. Review `tox.ini` and see the exceptions that I've made to the standard configuration.